### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server for interacting with PowerShell. This server provides tools for executing PowerShell commands, retrieving system information, managing modules, and more.
 
+<a href="https://glama.ai/mcp/servers/@posidron/mcp-powershell">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@posidron/mcp-powershell/badge" alt="PowerShell Server MCP server" />
+</a>
+
 ## Requirements
 
 - Node.js 18+


### PR DESCRIPTION
This PR adds a badge for the [PowerShell MCP Server](https://glama.ai/mcp/servers/@posidron/mcp-powershell) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@posidron/mcp-powershell">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@posidron/mcp-powershell/badge" alt="PowerShell Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.